### PR TITLE
Update logstash role for 5.x

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@
 ####################
 
 # the apt repository url to use for installing logstash from
-logstash_apt_repo_url: "http://packages.elastic.co/logstash/2.3/debian"
+logstash_apt_repo_url: "http://artifacts.elastic.co/logstash/5.x/apt"
 
 # the apt repository to use for installing logstash from
 logstash_apt_repos:
@@ -27,7 +27,7 @@ logstash_apt_repos:
 
 # the apt repository key url
 logstash_apt_keys:
-  - url: "https://packages.elastic.co/GPG-KEY-elasticsearch"
+  - url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
     state: "present"
 
 ###############################################

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@
 ####################
 
 # the apt repository url to use for installing logstash from
-logstash_apt_repo_url: "http://artifacts.elastic.co/logstash/5.x/apt"
+logstash_apt_repo_url: "http://artifacts.elastic.co/packages/5.x/apt"
 
 # the apt repository to use for installing logstash from
 logstash_apt_repos:

--- a/tasks/logstash_post_install.yml
+++ b/tasks/logstash_post_install.yml
@@ -121,7 +121,7 @@
     - logstash-post-install
 
 - name: Enable Logstash Plugins
-  command: "/opt/logstash/bin/logstash-plugin install {{ item }}"
+  command: "/usr/share/logstash/bin/logstash-plugin install {{ item }}"
   with_items: "{{ logstash_plugins }}"
   notify: Restart Logstash
   tags:

--- a/templates/08-apache.conf
+++ b/templates/08-apache.conf
@@ -1,6 +1,7 @@
 filter {
   if "horizon" in [tags] {
     grok {
+      patterns_dir => ["/opt/logstash/patterns"]
       match => {
        "message" => [ "%{COMMONAPACHELOG}",
                       "\[%{APACHE_ERROR_TIMESTAMP:timestamp}\] \[%{DATA:module}:%{DATA:loglevel}\] \[pid %{POSINT:apache_pid}\:tid %{POSINT:apache_tid}\] ?(?:\[client %{IP:clientip}:%{POSINT:clientport}\] )?%{GREEDYDATA:logmessage}" ]

--- a/templates/13-swift.conf
+++ b/templates/13-swift.conf
@@ -7,6 +7,7 @@ filter {
     }
 
     grok {
+      patterns_dir => ['/opt/logstash/patterns']
       match => {
         "logmessage" => [
           "%{COMBINEDAPACHELOG}",

--- a/templates/19-nginx.conf
+++ b/templates/19-nginx.conf
@@ -2,6 +2,7 @@ filter {
   if "nginx" in [tags] {
     if "nginx-access" in [tags] {
       grok {
+        patterns_dir => ['/opt/logstash/patterns']
         match => {
           "message" => "%{IP:client_ip} - %{USER:client_user} \[%{HTTPDATE:timestamp}\]  \"%{WORD:verb} %{NOTSPACE:request} HTTP/%{NUMBER:http_version}\" %{INT:response_code} %{INT:bytes} %{QUOTEDSTRING:referer} %{QUOTEDSTRING:user_agent} %{QUOTEDSTRING:gzip_ratio}"
         }
@@ -9,6 +10,7 @@ filter {
     }
     if "nginx-error" in [tags] {
       grok {
+        patterns_dir => ['/opt/logstash/patterns']
         match => {
           "message" => "%{NGINX_ERROR_TIMESTAMP:timestamp} \[%{LOGLEVEL:loglevel}\] %{GREEDYDATA:error_msg}"
         }

--- a/vars/ubuntu-16.04.yml
+++ b/vars/ubuntu-16.04.yml
@@ -16,4 +16,4 @@
 # the apt packages to install
 logstash_apt_packages:
   - logstash
-  - openjdk-8-jre-headless
+  - openjdk-9-jre-headless

--- a/vars/ubuntu-16.04.yml
+++ b/vars/ubuntu-16.04.yml
@@ -16,4 +16,4 @@
 # the apt packages to install
 logstash_apt_packages:
   - logstash
-  - openjdk-9-jre-headless
+  - openjdk-8-jre-headless


### PR DESCRIPTION
These commits update the logstash role for the 5.x version.  As of `05/15/2017` this will install and work with `5.4.0`.