### PR TITLE
This is to fix the example hostvars variable pull.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,6 @@ Usage Example
       hosts: logstash_all
       user: root
       vars:
-        - elasticsearch_host: hostvars[groups['elasticsearch'][0]]['container_address']
+        - elasticsearch_host: "{{ hostvars[groups['elasticsearch'][0]]['container_address'] }}"
       roles:
         - role: "rpc-role-logstash"


### PR DESCRIPTION
Author: Shannon Mitchell <shannon.mitchell@rackspace.com>
Date: Thu May 25 08:51:22 CDT 2017

The example is missing the jinja2 expressions template brackets
to translate to the variable value properly.