### PR TITLE
Fix missing variable identifiers

### DIFF
--- a/tasks/logstash_install.yml
+++ b/tasks/logstash_install.yml
@@ -23,7 +23,7 @@
   until: install_apt_packages|success
   retries: 5
   delay: 2
-  with_items: logstash_apt_packages
+  with_items: "{{ logstash_apt_packages }}"
   tags:
     - logstash-apt-packages
 

--- a/templates/99-output.conf
+++ b/templates/99-output.conf
@@ -2,7 +2,7 @@
 output {
     elasticsearch {
         template_overwrite => true
-        hosts => ['{{ hostvars[groups['elasticsearch'][0]]['container_address'] }}:{{ elasticsearch_tcp_port }}']
+        hosts => ['{{ hostvars[groups['elasticsearch'][0]]['container_address'] }}:{{ elasticsearch_http_port }}']
     }
 }
 #===============================================================================


### PR DESCRIPTION
With the later versions of Ansible, it's required to use proper variable syntax.