### PR TITLE
Inteligently determine ElasticSearch Host

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Default variables in defaults/main.yml
 - **logstash_tcp_port**: Logstash input port listen for tcp/json events(default: 5140)
 - **logstash_beats_port**: Logstash input port to listen for filebeat events(default: 5044) 
 - **elasticsearch_host**: Logstash output host for local elasticsearch services(default: localhost)
-- **elasticsearch_tcp_port**: Logstash output port for local elasticsearch services(default: 9200)
+- **elasticsearch_http_port**: Logstash output port for local elasticsearch services(default: 9200)
 - **logstash-plugins**: Plugins needed for input/output entries. (logstash-input-beats needed for filbeat input entry)
 - **logging_upgrade**: Can set to true when running ansible to enable an upgrade of logstash.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,7 @@ logstash_tcp_port: 5140
 logstash_beats_port: 5044
 
 # the target elasticsearch cluster settings
-elasticsearch_host: "{{ hostvars[groups['elasticsearch'][0]]['container_address'] | default(localhost} }}"
+elasticsearch_host: "{{ hostvars[groups['elasticsearch'][0]]['container_address'] | default(localhost) }}"
 elasticsearch_http_port: 9200
 elasticsearch_tcp_port: 9300
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,7 @@ logstash_tcp_port: 5140
 logstash_beats_port: 5044
 
 # the target elasticsearch cluster settings
-elasticsearch_host: "{{ hostvars[groups['elasticsearch'][0]]['container_address'] | default(localhost) }}"
+elasticsearch_host: "localhost"
 elasticsearch_http_port: 9200
 elasticsearch_tcp_port: 9300
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,7 +46,6 @@ logstash_beats_port: 5044
 # the target elasticsearch cluster settings
 elasticsearch_host: "localhost"
 elasticsearch_http_port: 9200
-elasticsearch_tcp_port: 9300
 
 logstash_plugins:
   - logstash-input-beats

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,8 +44,9 @@ logstash_tcp_port: 5140
 logstash_beats_port: 5044
 
 # the target elasticsearch cluster settings
-elasticsearch_host: "localhost"
-elasticsearch_tcp_port: 9200
+elasticsearch_host: "{{ hostvars[groups['elasticsearch'][0]]['container_address'] }}|default(localhost}"
+elasticsearch_http_port: 9200
+elasticsearch_tcp_port: 9300
 
 logstash_plugins:
   - logstash-input-beats

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,7 @@ logstash_tcp_port: 5140
 logstash_beats_port: 5044
 
 # the target elasticsearch cluster settings
-elasticsearch_host: "{{ hostvars[groups['elasticsearch'][0]]['container_address'] }}|default(localhost}"
+elasticsearch_host: "{{ hostvars[groups['elasticsearch'][0]]['container_address'] | default(localhost} }}"
 elasticsearch_http_port: 9200
 elasticsearch_tcp_port: 9300
 

--- a/tasks/logstash_install.yml
+++ b/tasks/logstash_install.yml
@@ -23,7 +23,7 @@
   until: install_apt_packages|success
   retries: 5
   delay: 2
-  with_items: logstash_apt_packages
+  with_items: "{{ logstash_apt_packages }}"
   tags:
     - logstash-apt-packages
 

--- a/templates/99-output.conf
+++ b/templates/99-output.conf
@@ -2,7 +2,7 @@
 output {
     elasticsearch {
         template_overwrite => true
-        hosts => ['{{ hostvars[groups['elasticsearch'][0]]['container_address'] }}:{{ elasticsearch_http_port }}']
+        hosts => ['{{ elasticsearch_host }}:{{ elasticsearch_http_port }}']
     }
 }
 #===============================================================================

--- a/templates/99-output.conf
+++ b/templates/99-output.conf
@@ -2,7 +2,7 @@
 output {
     elasticsearch {
         template_overwrite => true
-        hosts => ['{{ hostvars[groups['elasticsearch'][0]]['container_address'] }}:{{ elasticsearch_tcp_port }}']
+        hosts => ['{{ hostvars[groups['elasticsearch'][0]]['container_address'] }}:{{ elasticsearch_http_port }}']
     }
 }
 #===============================================================================


### PR DESCRIPTION
If there is an elasticsearch host in the inventory we use the `container_address` for the logstash endpoint, otherwise we use `localhost`.  This also renames `elasticsearch_tcp_port` to `elasticsearch_http_port` and adds the `elasticsearch_tcp_port` which defaults to `9300`.