### PR TITLE
[RI-255] Update apt package ordering

### DIFF
--- a/vars/ubuntu-14.04.yml
+++ b/vars/ubuntu-14.04.yml
@@ -15,5 +15,5 @@
 
 # the apt packages to install
 logstash_apt_packages:
-  - logstash
   - openjdk-7-jre-headless
+  - logstash

--- a/vars/ubuntu-16.04.yml
+++ b/vars/ubuntu-16.04.yml
@@ -15,5 +15,5 @@
 
 # the apt packages to install
 logstash_apt_packages:
-  - logstash
   - openjdk-8-jre-headless
+  - logstash


### PR DESCRIPTION
This ensures that the Java JRE is installed prior to the logstash
packages.

Issue: RI-255