### PR TITLE
[RI-308] Update logstash apt scheme

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@
 ####################
 
 # the apt repository url to use for installing logstash from
-logstash_apt_repo_url: "http://artifacts.elastic.co/packages/6.x/apt"
+logstash_apt_repo_url: "https://artifacts.elastic.co/packages/6.x/apt"
 
 # the apt repository to use for installing logstash from
 logstash_apt_repos:


### PR DESCRIPTION
The HTTP scheme is redirecting to HTTPS causing issues with the play.

Issue: RI-308